### PR TITLE
fix grub-installer/bootdev add all disk raid

### DIFF
--- a/debian/partitioning.cfg
+++ b/debian/partitioning.cfg
@@ -147,10 +147,8 @@ d-i partman/early_command string \
                 \$defaultignore{ } \
                 \$lvmok{ } \
                 lv_name{ lv_delete } ."; \
-    fi
-
-# Install grub in the first device (assuming it is not a USB stick)
-d-i grub-installer/bootdev string default
+    fi ; \
+    debconf-set grub-installer/bootdev "$DISKS"
 
 # Continue installation without /boot partition?
 d-i partman-auto-lvm/no_boot boolean true


### PR DESCRIPTION
grub should be placed on all disks. To run debian came with any drive.
default - only puts on the first disc.
